### PR TITLE
Add ability to set contour type

### DIFF
--- a/CardioMRI/src/edu/auburn/cardiomri/gui/GUIController.java
+++ b/CardioMRI/src/edu/auburn/cardiomri/gui/GUIController.java
@@ -602,7 +602,7 @@ public class GUIController  implements java.awt.event.ActionListener, MouseListe
 		this.gridModel.setCurrentImage(this.gIndex, this.sIndex, this.tIndex, this.iIndex);
 		this.metaDataModel.setCurrentImage(this.gIndex, this.sIndex, this.tIndex, this.iIndex);
 		this.imageModel.setCurrentImage(this.gIndex, this.sIndex, this.tIndex, this.iIndex);
-		this.imageModel.addContourToImage(new Contour());
+		this.imageModel.addContourToImage(new Contour(Contour.Type.DEFAULT));
 	}
 
 	// Setters

--- a/CardioMRI/src/edu/auburn/cardiomri/gui/ImageModel.java
+++ b/CardioMRI/src/edu/auburn/cardiomri/gui/ImageModel.java
@@ -82,7 +82,7 @@ public class ImageModel extends java.util.Observable {
 	public ImageModel() {
 //System.out.println("ImageModel()");
 		this.dImage = null;
-		contours.add(new Contour());
+		contours.add(new Contour(Contour.Type.DEFAULT));
 	}
 	
 	

--- a/CardioMRI/src/edu/auburn/cardiomri/gui/ImageView.java
+++ b/CardioMRI/src/edu/auburn/cardiomri/gui/ImageView.java
@@ -33,7 +33,7 @@ public class ImageView implements java.util.Observer {
 
 	private ImageDisplay display = null;
 	private Vector<Contour> contours = new Vector<Contour>();
-	private Contour contourObject = new Contour(), currentContour;
+	private Contour contourObject = new Contour(Contour.Type.DEFAULT), currentContour;
 
 	// Observer methods
 	@Override

--- a/CardioMRI/src/edu/auburn/cardiomri/lib/ContourCalc.java
+++ b/CardioMRI/src/edu/auburn/cardiomri/lib/ContourCalc.java
@@ -104,11 +104,9 @@ public final class ContourCalc {
 
         ContourCalc.sortPoints(controlPoints);
 
-        List<Point2D> rawPoints;
+        List<Point2D> rawPoints = new Vector<Point2D>(controlPoints);;
         if (isClosed) {
-            rawPoints = ContourCalc.createRepeatedList(controlPoints);
-        } else {
-            rawPoints = controlPoints;
+            rawPoints.add(rawPoints.get(0));
         }
 
         Vec2D[] points = new Vec2D[rawPoints.size()];
@@ -138,7 +136,7 @@ public final class ContourCalc {
      * @return A list three times the size of the input
      */
     public static List<Point2D> createRepeatedList(List<Point2D> points) {
-        int timesToRepeat = 3;
+        int timesToRepeat = 1;
         List<Point2D> allPoints = new Vector<Point2D>(points.size()
                 * timesToRepeat);
 


### PR DESCRIPTION
Contour's default constructor is now private. To instantiate one, you must now call the constructor passing in one of the types.

Some of my other changes accidentally got mixed in. Ignore the stuff about PathIterator and currentSegment.
