### PR TITLE
Change when the generate() function is called

### DIFF
--- a/CardioMRI/src/edu/auburn/cardiomri/datastructure/Contour.java
+++ b/CardioMRI/src/edu/auburn/cardiomri/datastructure/Contour.java
@@ -50,14 +50,7 @@ public class Contour implements Shape {
         }
 
         controlPoints = newList;
-    }
-
-    public void setGeneratedPoints(List<Point2D> points) {
-        if (points == null) {
-            throw new NullPointerException("List cannot be null");
-        }
-
-        generatedPoints = new Vector<Point2D>(points);
+        generatedPoints = ContourCalc.generate(controlPoints, isClosedCurve());
     }
 
     @Override
@@ -123,8 +116,6 @@ public class Contour implements Shape {
         // System.out.println(at.getScaleX());
         // System.out.println(at.getScaleY());
         // TODO Don't ignore the transform
-
-        setGeneratedPoints(ContourCalc.generate(controlPoints, isClosedCurve()));
 
         return new PathIterator() {
             private int index = 0;
@@ -206,6 +197,7 @@ public class Contour implements Shape {
     public void addControlPoint(double x, double y) {
         validateCoordinates(x, y);
         controlPoints.add(new Point2D(x, y));
+        generatedPoints = ContourCalc.generate(controlPoints, isClosedCurve());
     }
 
     /**
@@ -239,15 +231,11 @@ public class Contour implements Shape {
     }
 
     /**
-     * Returns a copy list of the points generated to create a smooth curve. The
-     * {@link ContourCalc#generate} function is called before the points are
-     * returned.
+     * Returns a copy of the list of points generated to create a smooth curve.
      *
      * @return copy of the internal list
      */
     public List<Point2D> getGeneratedPoints() {
-        // TODO Can this be changed so that it's only called when necessary?
-        setGeneratedPoints(ContourCalc.generate(controlPoints, isClosedCurve()));
         return new Vector<Point2D>(generatedPoints);
     }
 
@@ -267,6 +255,7 @@ public class Contour implements Shape {
      */
     public void setContourType(Type contourTypeIn) {
         contourType = contourTypeIn;
+        generatedPoints = ContourCalc.generate(controlPoints, isClosedCurve());
     }
 
     public Type getContourType() {

--- a/CardioMRI/src/edu/auburn/cardiomri/gui/GUIController.java
+++ b/CardioMRI/src/edu/auburn/cardiomri/gui/GUIController.java
@@ -454,7 +454,7 @@ public class GUIController  implements java.awt.event.ActionListener, MouseListe
                         }
                         Contour contour = new Contour(Contour.getTypeFromInt(contourType));
                         contour.setControlPoints(controlPoints);
-                        contour.setGeneratedPoints(generatedPoints);
+                        // contour.setGeneratedPoints(generatedPoints);
                         contours.add(contour);
                         if (line[0].equals("-1")) {
                             break;

--- a/CardioMRI/test/edu/auburn/cardiomri/test/datastructure/ContourTest.java
+++ b/CardioMRI/test/edu/auburn/cardiomri/test/datastructure/ContourTest.java
@@ -2,6 +2,7 @@ package edu.auburn.cardiomri.test.datastructure;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -66,15 +67,9 @@ public class ContourTest {
         contour.setControlPoints(list);
         List<Point2D> contourList = contour.getControlPoints();
 
-        for (int i = 0; i < list.size(); i++) {
-            assertEquals(list.get(i), contourList.get(i));
+        for (Point2D point : list) {
+            assertTrue(contourList.contains(point));
         }
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testSetGeneratedPointsThrowsNullPointerExceptionWhenGivenNullList() {
-        contour.setGeneratedPoints(null);
-        fail("Exception not thrown");
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Previously it would be called whenever the getter was called or when the contour was drawn on the screen.
Now it is called whenever addControlPoint(), setControlPoints(), or setContourType() is called.
